### PR TITLE
Update kiosk-installer.sh

### DIFF
--- a/kiosk-installer.sh
+++ b/kiosk-installer.sh
@@ -56,6 +56,7 @@ unclutter -idle 0.1 -grab -root &
 
 while :
 do
+  xrandr --auto
   chromium \
     --no-first-run \
     --start-maximized \


### PR DESCRIPTION
When using the script on the current latest version of Armbian, my monitor wasn't detected for some reason. `xrandr --auto` fixed it. For most setups with just 1 monitor it won't make any changes but it's a good fail-safe.